### PR TITLE
Create GitHub action for Jest coverage report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,5 +13,6 @@ jobs:
             - run: npm install
             - uses: ArtiomTr/jest-coverage-report-action@v2.0-rc.6
               with:
+                  annotations: none
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   threshold: 85

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,16 @@
+name: 'coverage'
+on:
+    pull_request:
+        branches:
+            - master
+            - main
+jobs:
+    coverage:
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        steps:
+            - uses: actions/checkout@v1
+            - uses: ArtiomTr/jest-coverage-report-action@v2.0-rc.6
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  threshold: 85

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,8 @@ jobs:
         runs-on: ubuntu-latest
         if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
-            - uses: actions/checkout@v1
+            - uses: actions/checkout@v2
+            - run: npm install
             - uses: ArtiomTr/jest-coverage-report-action@v2.0-rc.6
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jest coverage report will be generated and commented on new pull requests.

If coverage is under 85% threshold, the pull request will be rejected.

See:
https://github.com/ArtiomTr/jest-coverage-report-action